### PR TITLE
fix Dockerfile error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # -- build dependencies with debian(multiarch) --
 FROM python:3.7-slim AS build
 LABEL maintainer=me@tcw.im
-ARG PIPMIRROR=https://pypi.org/simple
+ARG PIPMIRROR=https://pypi.tuna.tsinghua.edu.cn/simple
 COPY requirements /requirements
 RUN pip install --timeout 30 --index $PIPMIRROR --user --no-cache-dir --no-warn-script-location -r /requirements/all.txt
 
@@ -10,7 +10,9 @@ FROM python:3.7-alpine
 ENV LOCAL_PKG="/root/.local"
 ENV sapic_isrun=true
 COPY --from=build ${LOCAL_PKG} ${LOCAL_PKG}
-RUN ln -sf ${LOCAL_PKG}/bin/flask ${LOCAL_PKG}/bin/gunicorn /bin/ && \
+RUN apk upgrade --no-cache && \
+    apk add --no-cache libgcc libstdc++ gcompat && \
+    ln -sf ${LOCAL_PKG}/bin/flask ${LOCAL_PKG}/bin/gunicorn /bin/ && \
     ln -sf $(which python) /python && \
     sed -i "s#$(which python)#/python#" /bin/gunicorn
 WORKDIR /picbed


### PR DESCRIPTION
I have open an issue [22](https://github.com/sapicd/sapic/issues/22), the Dockerfile use alpine as runtime image, but alpine install musl instead of glibc by default, so when you use docker compose up -d to start the project, webapp container would show error "ImportError: Error loading shared library libstdc++.so.6"
This PR install libc and gcompat to fix the problem. by the way, I change the default PIPMIRROR to tsinghua which speeds the build of chinese user.